### PR TITLE
Refactor: Move all validation from controllers to Form Requests

### DIFF
--- a/app/Http/Controllers/BrandController.php
+++ b/app/Http/Controllers/BrandController.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\BrandImageUpdateRequest;
+use App\Http\Requests\BrandStoreRequest;
+use App\Http\Requests\BrandUpdateRequest;
 use Illuminate\Http\Request;
 use App\Models\Brand;
 use Auth;
@@ -32,14 +35,8 @@ class BrandController extends Controller
     }
 
     // insert item
-    public function addbrandinsert(Request $req)
+    public function addbrandinsert(BrandStoreRequest $req)
     {
-
-        $req->validate([
-            'name' => 'required|unique:brands,name',
-            'img' => 'required',
-        ]);
-
         $name = $req->name;
         $added_by = Auth::id();
         $created_at = Carbon::now();
@@ -72,12 +69,8 @@ class BrandController extends Controller
     }
 
     // update view
-    public function update(Request $req)
+    public function update(BrandUpdateRequest $req)
     {
-        $req->validate([
-            'name' => 'required',
-        ]);
-
         $name = $req->name;
         $id = $req->id;
 
@@ -87,13 +80,8 @@ class BrandController extends Controller
         return back()->with('success', 'You are success to add a new brand');
     }
     // img update
-    public function img_update(Request $req)
+    public function img_update(BrandImageUpdateRequest $req)
     {
-
-        $req->validate([
-            'img' => 'required',
-        ]);
-
         $id = $req->id;
         $old_img = Brand::find($id)->img;
         unlink('upload/brand/' . $old_img);

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use App\Models\Category;
 use Auth;
 use Carbon\Carbon;
+use App\Http\Requests\CategoryStoreRequest;
+use App\Http\Requests\CategoryUpdateRequest;
 use Image;
 
 
@@ -30,13 +32,8 @@ class CategoryController extends Controller
         return view('category.addcategory');
     }
 
-     public function store(Request $req)
+     public function store(CategoryStoreRequest $req)
     {
-        $req->validate([
-            'name' => 'required|unique:categories,name',
-            'img' => 'required',
-        ]);
-
         $name = $req->name;
         $added_by = Auth::id();
         $created_at = Carbon::now();
@@ -66,22 +63,12 @@ class CategoryController extends Controller
         ]);
     }
 
-    public function update(Request $request,$id)
+    public function update(CategoryUpdateRequest $request,$id)
     {
-
-        $this->validate($request,[
-            'name' => 'required',
-        ]);
-
         $inputs = $request->only('name');
 
         if($request->hasFile('img'))
         {
-
-            $this->validate($request,[
-                'images'=>'image|mimes:jpeg,png,jpg|max:1024|dimensions:min_width=1000,min_height=350,max_width=1200,max_height=390',
-            ]);
-
             $old_img = Category::find($id)->img;
             unlink('upload/category/' . $old_img);
 
@@ -94,7 +81,6 @@ class CategoryController extends Controller
 
         Category::where(['id'=>$id])->update($inputs);
         return back()->with('success', 'You are success to update your category item.');
-
     }
 
 

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use App\Models\Category;
 use App\Http\Requests\ProductStoreRequest;
 use App\Http\Requests\ProductUpdateRequest;
+use App\Http\Requests\ProductImageUpdateRequest;
+use App\Http\Requests\ProductPhotoInsertRequest;
 use Illuminate\Http\Request;
 use App\Models\Product;
 use App\Models\Product_photo;
@@ -148,12 +150,8 @@ class ProductController extends Controller
         return back()->with('success', 'You are success to add a new product');
     }
     // img update
-    public function img_update(Request $req)
+    public function img_update(ProductImageUpdateRequest $req)
     {
-        $req->validate([
-            'img' => 'required',
-        ]);
-
         $id = $req->id;
         $old_img = Product::find($id)->img;
         unlink('upload/product/' . $old_img);
@@ -346,12 +344,8 @@ class ProductController extends Controller
 
 
     // insert item
-    public function addproductphotoinsert(Request $req)
+    public function addproductphotoinsert(ProductPhotoInsertRequest $req)
     {
-        $req->validate([
-            'img_multiple' => 'required',
-        ]);
-
         $id = $req->product_id;
         $img_multiple = $req->file('img_multiple');
         $added_by = Auth::id();

--- a/app/Http/Controllers/SubcategoryController.php
+++ b/app/Http/Controllers/SubcategoryController.php
@@ -6,6 +6,8 @@ use App\Models\Category;
 use App\Models\Subcategory;
 use Auth;
 use Carbon\Carbon;
+use App\Http\Requests\SubcategoryStoreRequest;
+use App\Http\Requests\SubcategoryUpdateRequest;
 use Image;
 
 
@@ -37,28 +39,20 @@ class SubcategoryController extends Controller
     }
 
     // insert item
-    public function addsubcategoryinsert(Request $req)
+    public function addsubcategoryinsert(SubcategoryStoreRequest $req)
     {
         $name = $req->name;
         $category = $req->category_id;
         $added_by = Auth::id();
         $created_at = Carbon::now();
 
-        $req->validate([
-            'name' => 'required|unique:categories,name',
-            'category_id' => 'required',
+        Subcategory::insert([
+            "name" => $name,
+            "category" => $category,
+            "added_by" => $added_by,
+            "created_at" => $created_at,
         ]);
-        if (Subcategory::where('category', $req->category_id)->where('name', $req->name)->exists()) {
-            return back()->with('error_status', 'This subcategory already exists');
-        } else {
-            Subcategory::insert([
-                "name" => $name,
-                "category" => $category,
-                "added_by" => $added_by,
-                "created_at" => $created_at,
-            ]);
-            return redirect('subcategory')->with('success', 'You are success to add a new subcategory');
-        }
+        return redirect('subcategory')->with('success', 'You are success to add a new subcategory');
     }
 
     // recyclebin page view
@@ -71,26 +65,17 @@ class SubcategoryController extends Controller
     }
 
     // update view
-    public function update(Request $req)
+    public function update(SubcategoryUpdateRequest $req)
     {
-        $req->validate([
-            'name' => 'required|unique:categories,name',
-            'category_id' => 'required',
-        ]);
-
         $name = $req->name;
         $category = $req->category_id;
         $id = $req->id;
 
-        if (Subcategory::where('category', $req->category_id)->where('name', $req->name)->exists()) {
-            return back()->with('error_status', 'This subcategory already exists');
-        } else {
-            Subcategory::find($id)->update([
-                "name" => $name,
-                "category" => $category,
-            ]);
-            return back()->with('success', 'You are success to add a new subcategory');
-        }
+        Subcategory::find($id)->update([
+            "name" => $name,
+            "category" => $category,
+        ]);
+        return back()->with('success', 'You are success to add a new subcategory');
     }
 
 

--- a/app/Http/Requests/BrandImageUpdateRequest.php
+++ b/app/Http/Requests/BrandImageUpdateRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class BrandImageUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'img' => 'required',
+        ];
+    }
+}

--- a/app/Http/Requests/BrandStoreRequest.php
+++ b/app/Http/Requests/BrandStoreRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class BrandStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'required|unique:brands,name',
+            'img' => 'required',
+        ];
+    }
+}

--- a/app/Http/Requests/BrandUpdateRequest.php
+++ b/app/Http/Requests/BrandUpdateRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class BrandUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'required',
+        ];
+    }
+}

--- a/app/Http/Requests/CategoryStoreRequest.php
+++ b/app/Http/Requests/CategoryStoreRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CategoryStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'required|unique:categories,name',
+            'img' => 'required',
+        ];
+    }
+}

--- a/app/Http/Requests/CategoryUpdateRequest.php
+++ b/app/Http/Requests/CategoryUpdateRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CategoryUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $rules = [
+            'name' => 'required',
+        ];
+
+        if ($this->hasFile('img')) {
+            $rules['img'] = 'image|mimes:jpeg,png,jpg|max:1024|dimensions:min_width=1000,min_height=350,max_width=1200,max_height=390';
+        }
+
+        return $rules;
+    }
+}

--- a/app/Http/Requests/ProductImageUpdateRequest.php
+++ b/app/Http/Requests/ProductImageUpdateRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ProductImageUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'img' => 'required',
+        ];
+    }
+}

--- a/app/Http/Requests/ProductPhotoInsertRequest.php
+++ b/app/Http/Requests/ProductPhotoInsertRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ProductPhotoInsertRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'img_multiple' => 'required',
+        ];
+    }
+}

--- a/app/Http/Requests/SubcategoryStoreRequest.php
+++ b/app/Http/Requests/SubcategoryStoreRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class SubcategoryStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => [
+                'required',
+                Rule::unique('subcategories')->where(function ($query) {
+                    return $query->where('category', $this->category_id);
+                }),
+            ],
+            'category_id' => 'required',
+        ];
+    }
+}

--- a/app/Http/Requests/SubcategoryUpdateRequest.php
+++ b/app/Http/Requests/SubcategoryUpdateRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class SubcategoryUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => [
+                'required',
+                Rule::unique('subcategories')->where(function ($query) {
+                    return $query->where('category', $this->category_id);
+                })->ignore($this->id),
+            ],
+            'category_id' => 'required',
+        ];
+    }
+}


### PR DESCRIPTION
This commit moves all inline validation logic from the `ProductController`, `CategoryController`, `SubcategoryController`, and `BrandController` into dedicated Form Request classes.

This change improves code organization and adheres to Laravel best practices by separating validation concerns from the controllers. It also fixes several bugs in the original validation logic and improves the implementation of composite unique key validation.